### PR TITLE
Update transaction_record.py

### DIFF
--- a/deafwave/wallet/transaction_record.py
+++ b/deafwave/wallet/transaction_record.py
@@ -64,4 +64,4 @@ class TransactionRecord(Streamable):
                     return uint32(block_index)
                 if postfarm_parent == self.additions[0].parent_coin_info:
                     return uint32(block_index)
-        return None
+        return uint32(block_index)


### PR DESCRIPTION
This is the goji fix for "> not supported between instance of NoneType and uint32" error when viewing the Wallet or Farm Summary. Not all forks seem to have this problem or need this fix, haven't tested for it's presence in deafwave-blockchain yet.

Hopefully it's unneeded, but here it is if you do you need it.